### PR TITLE
[esp] fix: add missing SSL socket compatibiliyt wrapper methods

### DIFF
--- a/esp/ftplib.py
+++ b/esp/ftplib.py
@@ -75,6 +75,7 @@ def _resolve_addr(addr):
 
 
 class socket:
+    """Compatibility wrapper."""
     def __init__(self, *args, **kw):
         if args and isinstance(args[0], _socket.socket):
             self._sock = args[0]
@@ -85,8 +86,17 @@ class socket:
         s, addr = self._sock.accept()
         return self.__class__(s), addr
 
-    def sendall(self, data):
-        return self._sock.write(data)
+    def recv(self, size):
+        if hasattr(self._sock, 'recv'):
+            return self._sock.recv(size)
+        else:
+            return self._sock.read(size)
+
+    def sendall(self, *args):
+        if hasattr(self._sock, 'send'):
+            return self._sock.send(*args)
+        else:
+            return self._sock.write(*args)
 
     def __getattr__(self, name):
         return getattr(self._sock, name)

--- a/tests/esp/test_retrbinary.py
+++ b/tests/esp/test_retrbinary.py
@@ -1,0 +1,16 @@
+from ftplibtls import FTP_TLS
+
+FTP_HOST = "192.168.0.1"
+FTP_PORT = 990
+FTP_USER = "joedoe"
+FTP_PASS = "abc123"
+
+ftp = FTP_TLS(FTP_HOST, FTP_PORT)
+ftp.login(FTP_USER, FTP_PASS)
+ftp.prot_p()
+filename = "test.txt"
+
+with open(filename, "wb") as fp:
+    result = ftp.retrbinary(f"RETR {filename}", fp.write)
+    print(f"FTP download of '{filename}', status: {result}")
+


### PR DESCRIPTION
Add test script for 'retrbinary' with FTP-over-TLS.

Fixes #20.